### PR TITLE
remove unnecessary www subdomain in necronux site urls

### DIFF
--- a/.github/CODE_OF_CONDUCT.md
+++ b/.github/CODE_OF_CONDUCT.md
@@ -8,4 +8,4 @@
 
 # The Necronux Code of Conduct
 
-The Code of Conduct for this repository [can be found online](https://www.necronux.nayanpatil.space/conduct.html).
+The Code of Conduct for this repository [can be found online](https://necronux.nayanpatil.space/conduct.html).

--- a/README.md
+++ b/README.md
@@ -15,10 +15,10 @@ A cross-platform robust meta-orchestrator for automation tools, scripts, and con
 [Website][Necronux] | [Getting Started] | [Learn] | [Documentation] | [Contributing]
 </div>
 
-[Necronux]: https://www.necronux.nayanpatil.space/
-[Getting Started]: https://www.necronux.nayanpatil.space/learn/get-started
-[Learn]: https://www.necronux.nayanpatil.space/learn
-[Documentation]: https://www.necronux.nayanpatil.space/docs
+[Necronux]: https://necronux.nayanpatil.space/
+[Getting Started]: https://necronux.nayanpatil.space/learn/get-started
+[Learn]: https://necronux.nayanpatil.space/learn
+[Documentation]: https://necronux.nayanpatil.space/docs
 [Contributing]: .github/CONTRIBUTING.md
 
 ## Why Necronux?
@@ -32,7 +32,7 @@ A cross-platform robust meta-orchestrator for automation tools, scripts, and con
 
 For installation, read ["Installation Guide"] from the docs.
 
-["Installation Guide"]: https://www.necronux.nayanpatil.space/docs/install
+["Installation Guide"]: https://necronux.nayanpatil.space/docs/install
 
 ## Installing from Source
 


### PR DESCRIPTION
### What does this PR try to resolve?
Removes www from necronux site urls as www falls under second level subdomain in this case which is too long conventionally.